### PR TITLE
Fix django import error

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -1,11 +1,11 @@
 from mongoengine.queryset.visitor import Q
+import django
 
 # django application 起動
 django.setup()
 
 from ctirs.core.mongo.documents_stix import StixFiles
 from ctirs.core.mongo.documents import TaxiiServers, InformationSources, Vias, Communities
-import django
 import yaml
 import datetime
 import dateutil.tz


### PR DESCRIPTION
"supervisorctl" command causes import error in /var/log/opentaxii.log: 

```
 File "/opt/s-tip/txs/src/api.py", line 4, in <module>
    django.setup()
NameError: name 'django' is not defined
```

It seems that import django should be moved bofore.