### PR TITLE
Fixed an issue about an unexpected periodically reboot.

### DIFF
--- a/init.d/supervisord.conf
+++ b/init.d/supervisord.conf
@@ -8,6 +8,7 @@ chmod=0700                       ; sockef file mode (default 0700)
 logfile=/var/log/supervisor/supervisord.log ; (main log file;default $CWD/supervisord.log)
 pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
 childlogdir=/var/log/supervisor            ; ('AUTO' child log dir, default $TEMP)
+nodaemon=true
 
 ; the below section must remain in the config file for RPC
 ; (supervisorctl/web interface) to work, additional interfaces may be


### PR DESCRIPTION
I found that `stip-txs` has unexpectedly restarted every 80 seconds.
I checked the `opentaxii.log` and `supervisor.log` and `syslog`.
It seems that the reboots occurred when a daemon setting of `supervisor` is true.
We should that `nodaemon=true` added in `supervisor.conf' explicitly.

---

`stip-txs` が 80 秒起きに再起動する事象が発生していました。
`opentaxii.log`, `supervisor.log`, `syslog` を確認したところ、
この事象は `supervisor` がデーモン起動しようとして失敗して再起動しているようでした。
そこで、`supervisor.conf` に明示的に `nodaemon=true` とすることで、daemon 起動しないようにすべきです。



 